### PR TITLE
fix: CORS Error #16 #17

### DIFF
--- a/src/utils/uptimerobot.js
+++ b/src/utils/uptimerobot.js
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import Axios from 'axios';
 import { fixed } from './helper';
 
-const Api = 'https://uptimerobot.renfei.workers.dev/v2/getMonitors';
+const Api = 'https://uptimerobot-api.renfei.net/v2/getMonitors';
 
 export const GetMonitors = async (apikey, days) => {
 

--- a/src/utils/uptimerobot.js
+++ b/src/utils/uptimerobot.js
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import Axios from 'axios';
 import { fixed } from './helper';
 
-const Api = 'https://api.uptimerobot.com/v2/getMonitors';
+const Api = 'https://uptimerobot.renfei.workers.dev/v2/getMonitors';
 
 export const GetMonitors = async (apikey, days) => {
 


### PR DESCRIPTION
2021年2月9日，UptimeRobot对[APIv2进行了更新（CORS标头等）](https://blog.uptimerobot.com/latest-apiv2-changes-cors-headers/)，这就导致了跨域请求的问题。
为了解决CORS跨域请求的问题，我在 cloudflare 搭建了反向代理，来临时解决这个问题，但每天只能支持 10万次请求，所以建议增加自行搭建反代服务的教程和说明。
